### PR TITLE
Feature - 002 - publish module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+.flattened-pom.xml
 
 ### STS ###
 .apt_generated

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
 # common
 common package with submodules used in many projects
+
+## Structure
+
+```
+common
+-> common-bom
+-> common-dto
+```
+
+## Description
+1. common is the main module and contains the BOM and DTO modules as submodules.
+2. common-bom is the submodule imported as "dependency management" in the other modules. Its pom points to the other submodules' poms.
+3. common-dto is the submodule containing the DTOs that are commonly used by other projects.
+
+
+## Github packages
+In order to make other projects use this common package, it is needed to publish this module on the web. 
+It could have been done in several ways (maven central repo, nexus, etc.), but for now the choice fell on Github packages.
+
+### Github packages with maven documentation
+This is the guide: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry
+
+### Settings.xml
+In order to make maven able to publish and download the packages from Github, it is needed to add the following code to the settings.xml file.
+This is the example of my settings.xml file:
+```
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <activeProfiles>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
+
+  <profiles>
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>central</id>
+          <url>https://repo1.maven.org/maven2</url>
+        </repository>
+        <repository>
+          <id>my-github-common</id>
+          <url>https://maven.pkg.github.com/alessandrogranato/common</url>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+  <servers>
+    <server>
+      <id>my-github-common</id>
+      <username>alessandrogranato</username>
+      <password><MY_TOKEN></password>
+    </server>
+  </servers>
+</settings>
+
+```
+

--- a/common-bom/pom.xml
+++ b/common-bom/pom.xml
@@ -3,28 +3,29 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <groupId>com.pyrosandro</groupId>
         <artifactId>common</artifactId>
+        <groupId>com.pyrosandro</groupId>
         <version>${revision}</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>common-dto</artifactId>
+    <artifactId>common-bom</artifactId>
+    <description>common bill of material module used by other modules inside dependencyManagement tag</description>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
-    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.pyrosandro</groupId>
+                <artifactId>common-dto</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,19 +4,16 @@
 	<modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
 
-<!--    <parent>-->
-<!--		<groupId>org.springframework.boot</groupId>-->
-<!--		<artifactId>spring-boot-starter-parent</artifactId>-->
-<!--		<version>2.6.4</version>-->
-<!--		<relativePath/> &lt;!&ndash; lookup parent from repository &ndash;&gt;-->
-<!--	</parent>-->
 	<groupId>com.pyrosandro</groupId>
 	<artifactId>common</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>${revision}</version>
 	<name>common</name>
 	<description>common module</description>
+
 	<properties>
+		<revision>0.1.0-SNAPSHOT</revision>
 		<java.version>11</java.version>
+		<flatten.maven.plugin.version>1.1.0</flatten.maven.plugin.version>
 		<lombok.version>1.18.6</lombok.version>
 		<spring.boot.version>2.6.4</spring.boot.version>
 	</properties>
@@ -38,28 +35,47 @@
 		</dependencies>
 	</dependencyManagement>
 
-<!--	<dependencies>-->
-<!--		<dependency>-->
-<!--			<groupId>org.springframework.boot</groupId>-->
-<!--			<artifactId>spring-boot-starter</artifactId>-->
-<!--		</dependency>-->
-
-
-<!--		<dependency>-->
-<!--			<groupId>org.springframework.boot</groupId>-->
-<!--			<artifactId>spring-boot-starter-test</artifactId>-->
-<!--			<scope>test</scope>-->
-<!--		</dependency>-->
-<!--	</dependencies>-->
-
 	<modules>
+		<module>common-bom</module>
 		<module>common-dto</module>
 	</modules>
 
 	<build>
 		<plugins>
-
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>${flatten.maven.plugin.version}</version>
+				<configuration>
+					<updatePomFile>true</updatePomFile>
+					<flattenMode>resolveCiFriendliesOnly</flattenMode>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
+
+	<distributionManagement>
+		<repository>
+			<id>my-github-common</id>
+			<name>GitHub alessandrogranato common repo</name>
+			<url>https://maven.pkg.github.com/alessandrogranato/common</url>
+		</repository>
+	</distributionManagement>
 
 </project>


### PR DESCRIPTION
- create submodule common-bom that will be imported as dependency management by other modules
- add flatten plugin in main pom so that submodules can refer to correct main pom's version during builds
- add variable revision representing version
- add repository to deploy builds in main module's pom
- change version to variable revision inside common-dto's pom
- add .flattened-pom.xml in .gitignore file
- change README.md file adding all the info describing the common module and how to publish/import modules using github packages