### PR TITLE
Feature - 003 - common error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ common package with submodules used in many projects
 common
 -> common-bom
 -> common-dto
+-> common-error
 ```
 
 ## Description
 1. common is the main module and contains the BOM and DTO modules as submodules.
 2. common-bom is the submodule imported as "dependency management" in the other modules. Its pom points to the other submodules' poms.
 3. common-dto is the submodule containing the DTOs that are commonly used by other projects.
-
+4. common-error is the submodule containing the classes that are commonly used to handle errors.
 
 ## Github packages
 In order to make other projects use this common package, it is needed to publish this module on the web. 
@@ -21,6 +22,8 @@ It could have been done in several ways (maven central repo, nexus, etc.), but f
 
 ### Github packages with maven documentation
 This is the guide: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry
+
+## How to use common package in other projects
 
 ### Settings.xml
 In order to make maven able to publish and download the packages from Github, it is needed to add the following code to the settings.xml file.
@@ -64,4 +67,126 @@ This is the example of my settings.xml file:
 </settings>
 
 ```
+
+### Import the common package as dependency
+In order to use this package in other projects, it is needed to add the following code to the parent pom.xml file of the destination project:
+```
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.pyrosandro</groupId>
+				<artifactId>common-bom</artifactId>
+				<version>${common-bom-version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+```
+Where **${common-bom-version}** is the version of the common-bom module defined in the property tag of the parent pom.xml file.
+For example:
+```
+    <properties>
+        <common-bom-version>1.0.0</common-bom-version>
+    </properties>
+```
+
+Then, inside the submodule pom.xml file where you need common features, it is needed to add the following code:
+```
+    <dependencies>
+        <dependency>
+            <groupId>com.pyrosandro</groupId>
+            <artifactId>common-dto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.pyrosandro</groupId>
+            <artifactId>common-error</artifactId>
+        </dependency>
+    </dependencies>
+```
+Finally, it is needed to add the following code to the settings.xml file:
+
+### Implement the destination module's custom error handling that is based on common-error module
+
+If you need only common error messages in your destination module, you are already good to go.
+If you need custom error messages, you need to do the following things in your destination module:
+
+1. Create a class that handles your custom exceptions. An example:
+```
+@Data
+public class AuthException extends Exception {
+
+    private final AuthErrorConstants errorCode;
+    private final Object[] errorArgs;
+
+    public AuthException(AuthErrorConstants errorCode, Object[] errorArgs) {
+        this.errorCode = errorCode;
+        this.errorArgs = errorArgs;
+    }
+}
+```
+
+2. Create a class that handles your custom error constants. An example:
+``` 
+@RequiredArgsConstructor
+@Getter
+public enum AuthErrorConstants {
+
+    RESOURCE_NOT_FOUND(1001),
+    INVALID_JWT_SIGNATURE(1002),
+    MALFORMED_JWT(1003),
+    ;
+
+    public final int code;
+
+}
+```
+
+3. Create a class that extends GlobalExceptionHandler and handles your custom exceptions. An example:
+``` 
+@Slf4j
+@ControllerAdvice
+public class AuthExceptionHandler extends GlobalExceptionHandler {
+
+    public AuthExceptionHandler(@Value("${common.printstacktrace:false}") boolean printStackTrace, MessageSource messageSource) {
+        super(printStackTrace, messageSource);
+    }
+
+
+    @ExceptionHandler({AuthException.class})
+    public ResponseEntity<Object> handleAuthException(AuthException ex, WebRequest request) {
+
+        switch (ex.getErrorCode()) {
+            case RESOURCE_NOT_FOUND:
+                log.error("Resource not found", ex);
+                return buildErrorDTO(ex, messageSource.getMessage(String.valueOf(ex.getErrorCode().getCode()), ex.getErrorArgs(), Locale.getDefault()), HttpStatus.NOT_FOUND, request);
+            case INVALID_JWT_SIGNATURE:
+            case MALFORMED_JWT:
+                log.error("unauthorized access", ex);
+                return buildErrorDTO(ex, messageSource.getMessage(String.valueOf(ex.getErrorCode().getCode()), ex.getErrorArgs(), Locale.getDefault()), HttpStatus.UNAUTHORIZED, request);
+            default:
+                log.error("generic error", ex);
+                return buildErrorDTO(ex, HttpStatus.INTERNAL_SERVER_ERROR, request);
+        }
+    }
+}
+```
+
+4. Create a property file used by the messageSource bean. An example would be to have a file called **src/main/resources/auth-messages.properties** with the following content:
+```
+1001=Resource not found with path {0}
+1002=Unauthorized - Invalid JWT signature
+1003=Unauthorized - Invalid JWT token
+
+``` 
+
+5. Add the messageSource properties to use both the common-messages.properties and the auth-messages.properties inside the application.yml file of the target module. An example:
+``` 
+spring:
+    messages:
+        basename: auth-messages,common-messages
+```
+
+
+
 

--- a/TODO
+++ b/TODO
@@ -1,0 +1,1 @@
+Add code in ErrorDTO

--- a/common-bom/pom.xml
+++ b/common-bom/pom.xml
@@ -25,6 +25,11 @@
                 <artifactId>common-dto</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.pyrosandro</groupId>
+                <artifactId>common-error</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/common-error/pom.xml
+++ b/common-error/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.pyrosandro</groupId>
+        <artifactId>common</artifactId>
+        <version>${revision}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>common-error</artifactId>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pyrosandro</groupId>
+            <artifactId>common-dto</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>${commons.lang.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/common-error/src/main/java/com/pyrosandro/common/error/CommonErrorAutoConfiguration.java
+++ b/common-error/src/main/java/com/pyrosandro/common/error/CommonErrorAutoConfiguration.java
@@ -1,0 +1,14 @@
+package com.pyrosandro.common.error;
+
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Configuration
+@PropertySource({"classpath:common-error.properties"})
+@ComponentScan(basePackages = "com.pyrosandro.common.error")
+@AutoConfigureBefore(MessageSourceAutoConfiguration.class)
+public class CommonErrorAutoConfiguration {
+}

--- a/common-error/src/main/java/com/pyrosandro/common/error/CommonException.java
+++ b/common-error/src/main/java/com/pyrosandro/common/error/CommonException.java
@@ -1,0 +1,21 @@
+package com.pyrosandro.common.error;
+
+import lombok.Data;
+
+@Data
+public class CommonException extends RuntimeException {
+
+    private final ErrorConstants errorCode;
+    private final Object[] errorArgs;
+
+    public CommonException(ErrorConstants errorCode, Object[] errorArgs, String errorMessage, Throwable throwable) {
+        super(errorMessage, throwable);
+        this.errorCode = errorCode;
+        this.errorArgs = errorArgs;
+    }
+
+
+
+
+
+}

--- a/common-error/src/main/java/com/pyrosandro/common/error/ErrorConstants.java
+++ b/common-error/src/main/java/com/pyrosandro/common/error/ErrorConstants.java
@@ -1,0 +1,17 @@
+package com.pyrosandro.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorConstants {
+
+    OK(0),
+    GENERIC_ERROR(100),
+    CONSTRAINT_VALIDATION_ERROR(101),
+    ;
+
+    public final int code;
+
+}

--- a/common-error/src/main/java/com/pyrosandro/common/error/GlobalExceptionHandler.java
+++ b/common-error/src/main/java/com/pyrosandro/common/error/GlobalExceptionHandler.java
@@ -1,0 +1,101 @@
+package com.pyrosandro.common.error;
+
+import com.pyrosandro.common.dto.ErrorDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.MessageSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import java.util.Locale;
+
+@Slf4j
+@ControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    protected final boolean printStackTrace;
+
+    protected final MessageSource messageSource;
+
+    public GlobalExceptionHandler(@Value("${common.printstacktrace:false}") boolean printStackTrace, MessageSource messageSource) {
+        this.printStackTrace = printStackTrace;
+        this.messageSource = messageSource;
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<Object> handleConstraintViolationException(ConstraintViolationException ex, WebRequest request) {
+        log.error("ConstraintViolation Validation error occurred", ex);
+
+        ErrorDTO errorDTO = new ErrorDTO(HttpStatus.BAD_REQUEST, messageSource.getMessage(String.valueOf(ErrorConstants.CONSTRAINT_VALIDATION_ERROR.getCode()), null, Locale.getDefault()));
+        for (ConstraintViolation constraintViolation : ex.getConstraintViolations()) {
+            errorDTO.addValidationError(constraintViolation.getPropertyPath().toString(), constraintViolation.getMessage());
+        }
+        if (printStackTrace) {
+            errorDTO.setStackTrace(ExceptionUtils.getStackTrace(ex));
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorDTO);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        log.error("MethodArgumentNotValid Validation error occurred", ex);
+
+        ErrorDTO errorDTO = new ErrorDTO(HttpStatus.BAD_REQUEST, messageSource.getMessage(String.valueOf(ErrorConstants.CONSTRAINT_VALIDATION_ERROR.getCode()), null, Locale.getDefault()));
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            errorDTO.addValidationError(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        if (printStackTrace) {
+            errorDTO.setStackTrace(ExceptionUtils.getStackTrace(ex));
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorDTO);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<Object> handleAllUncaughtRuntimeExceptions(RuntimeException ex, WebRequest request) {
+        log.error("Unknown error occurred", ex);
+        return buildErrorDTO(ex, HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ResponseEntity<Object> handleAllUncaughtExceptions(Exception ex, WebRequest request) {
+        log.error("Unknown error occurred", ex);
+        return buildErrorDTO(ex, HttpStatus.INTERNAL_SERVER_ERROR, request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleExceptionInternal(Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatus status, WebRequest request) {
+        return buildErrorDTO(ex, status, request);
+    }
+
+    protected ResponseEntity<Object> buildErrorDTO(Exception ex, String message, HttpStatus status, WebRequest request) {
+        ErrorDTO errorDTO = new ErrorDTO(status, message);
+        if (printStackTrace) {
+            errorDTO.setStackTrace(ExceptionUtils.getStackTrace(ex));
+        }
+        return ResponseEntity.status(status).body(errorDTO);
+    }
+
+    protected ResponseEntity<Object> buildErrorDTO(Exception ex, HttpStatus status, WebRequest request) {
+        ErrorDTO errorDTO = new ErrorDTO(status, ex.getMessage());
+        if (printStackTrace) {
+            errorDTO.setStackTrace(ExceptionUtils.getStackTrace(ex));
+        }
+        return ResponseEntity.status(status).body(errorDTO);
+    }
+
+}

--- a/common-error/src/main/resources/META-INF/spring.factories
+++ b/common-error/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.pyrosandro.common.error.CommonErrorAutoConfiguration

--- a/common-error/src/main/resources/common-error.properties
+++ b/common-error/src/main/resources/common-error.properties
@@ -1,0 +1,1 @@
+spring.messages.basename=common-messages

--- a/common-error/src/main/resources/common-messages.properties
+++ b/common-error/src/main/resources/common-messages.properties
@@ -1,0 +1,3 @@
+0=OK
+100=Generic Error
+101=Constraint validation error

--- a/pom.xml
+++ b/pom.xml
@@ -11,11 +11,12 @@
 	<description>common module</description>
 
 	<properties>
-		<revision>0.1.0-SNAPSHOT</revision>
+		<revision>0.2.0-SNAPSHOT</revision>
 		<java.version>11</java.version>
 		<flatten.maven.plugin.version>1.1.0</flatten.maven.plugin.version>
 		<lombok.version>1.18.6</lombok.version>
 		<spring.boot.version>2.6.4</spring.boot.version>
+		<commons.lang.version>2.6</commons.lang.version>
 	</properties>
 
 	<dependencyManagement>
@@ -26,18 +27,25 @@
 				<version>${lombok.version}</version>
 			</dependency>
 			<dependency>
+				<groupId>commons-lang</groupId>
+				<artifactId>commons-lang</artifactId>
+				<version>${commons.lang.version}</version>
+			</dependency>
+			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>
 				<version>${spring.boot.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 
 	<modules>
 		<module>common-bom</module>
 		<module>common-dto</module>
+		<module>common-error</module>
 	</modules>
 
 	<build>


### PR DESCRIPTION
- Create common-error submodule
- Create CommonException class to handle common exceptions
- Create ErrorConstants class to enum common errors
- Create GlobalExceptionHandler to manage and display common errors
- Create CommonErrorAutoConfiguration to be able to auto configure common-error module when imported by other projects
- Create spring.factories file to apply the autoconfiguration
- Create common-error.properties for properties related to common-error management
- Create common-messages.properties to have error descriptions handled by MessageSource
- Update README.md file to explain how to import and use the common-error module in other projects
- Create TODO file to maintain track of what to do next